### PR TITLE
chore: update mods

### DIFF
--- a/versions/fabric/1.20.1/index.toml
+++ b/versions/fabric/1.20.1/index.toml
@@ -38,7 +38,7 @@ hash = "c402465b389607f17ecd45b44d5aef66a3750cef2d1c435189aaf81b667715b8"
 
 [[files]]
 file = "mods/c2me-fabric.pw.toml"
-hash = "64a244469b7ce7be7e6ceabedd69d17e573a0b92d6e29c661fc6c490afa965d8"
+hash = "ade864be9b0be5ed45fe53e621c9bd30778cbf2cfbf702b27aca203abf1d7bf7"
 metafile = true
 
 [[files]]
@@ -78,7 +78,7 @@ metafile = true
 
 [[files]]
 file = "mods/fabric-api.pw.toml"
-hash = "54a806dbb8f15f8acd7a7d1dc528ce6242acfd8567784e96477d3026798718ae"
+hash = "d9f5084f3684add4a72eac5500df626a92e5e36eda54d9527ad1da0a16c2060a"
 metafile = true
 
 [[files]]
@@ -108,7 +108,7 @@ metafile = true
 
 [[files]]
 file = "mods/ixeris.pw.toml"
-hash = "b81cf8cf53cfe7231b0cacf555af00dedf55f0419895af4bde0e77764fbd04d9"
+hash = "d0f0397d63ff769cf17cad2326353ebfe3231c8fed929eff26c8cd27871f91c3"
 metafile = true
 
 [[files]]

--- a/versions/fabric/1.20.1/mods/c2me-fabric.pw.toml
+++ b/versions/fabric/1.20.1/mods/c2me-fabric.pw.toml
@@ -1,13 +1,13 @@
 name = "Concurrent Chunk Management Engine (Fabric)"
-filename = "c2me-fabric-mc1.20.1-0.2.0+alpha.11.16.jar"
+filename = "c2me-fabric-mc1.20.1-0.2.0+alpha.11.18.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/VSNURh3q/versions/s4WOiNtz/c2me-fabric-mc1.20.1-0.2.0%2Balpha.11.16.jar"
+url = "https://cdn.modrinth.com/data/VSNURh3q/versions/fyt7FtgA/c2me-fabric-mc1.20.1-0.2.0%2Balpha.11.18.jar"
 hash-format = "sha512"
-hash = "359c715fd6a0464192d36b4d9dbb7927776eaae498f0cab939b49740fc724bda83aaf4f069f395dc5975d1e82762ee3b602111d9375eb27ab6f5360c4b17f2ff"
+hash = "5068a570cde47f105ec17bde14d0004c5f5d3f73b89d8e23a8ac5955a35f4a0dc59ff1d9e0626bfb29e04a7329dc0e9e089f41d637aff6843a6cd43d0573ece9"
 
 [update]
 [update.modrinth]
 mod-id = "VSNURh3q"
-version = "s4WOiNtz"
+version = "fyt7FtgA"

--- a/versions/fabric/1.20.1/mods/fabric-api.pw.toml
+++ b/versions/fabric/1.20.1/mods/fabric-api.pw.toml
@@ -1,13 +1,13 @@
 name = "Fabric API"
-filename = "fabric-api-0.92.8+1.20.1.jar"
+filename = "fabric-api-0.92.9+1.20.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/aLxYjsiv/fabric-api-0.92.8%2B1.20.1.jar"
+url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/hu6gukgT/fabric-api-0.92.9%2B1.20.1.jar"
 hash-format = "sha512"
-hash = "c1cb983e66cb09e74d318c5e9093296be56968be36626eaa603a08826e2bf0ebde7b81ec3da81580c5e6ceae22fc29b59efe2f4d5fd9933c1352f89a878c24a4"
+hash = "9437e8561c0ce83031607f3015a4d487553c4cdd22ec91e2c874976139d1dcfd3ef909f78b89e8c3a6c35fdab6d79b34ed9624c3462ed2dfbaa85188b7249c02"
 
 [update]
 [update.modrinth]
 mod-id = "P7dR8mSH"
-version = "aLxYjsiv"
+version = "hu6gukgT"

--- a/versions/fabric/1.20.1/mods/ixeris.pw.toml
+++ b/versions/fabric/1.20.1/mods/ixeris.pw.toml
@@ -1,13 +1,13 @@
 name = "Ixeris"
-filename = "Ixeris-4.2.0+1.20.1-fabric.jar"
+filename = "Ixeris-4.3.0+1.20.1-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/p8RJPJIC/versions/RrzJqB3x/Ixeris-4.2.0%2B1.20.1-fabric.jar"
+url = "https://cdn.modrinth.com/data/p8RJPJIC/versions/VnvZLEM3/Ixeris-4.3.0%2B1.20.1-fabric.jar"
 hash-format = "sha512"
-hash = "8e0fab6dbd7aec9a15800a6ef7043b4bbb5df4a4a1792c932de12201b9893b3af65588606a9fd6141bfa7d7346071fd463c23b550b9e170f34a7555dd5f9a2c1"
+hash = "3b3b2c2215704149a99e7aef1ab15a26437187e6c077e3d7487f8cf01af590685b9cea310f87dd7d6c85d06655c8b01fc08d56bbc1bc89fb956bed9036923be8"
 
 [update]
 [update.modrinth]
 mod-id = "p8RJPJIC"
-version = "RrzJqB3x"
+version = "VnvZLEM3"

--- a/versions/fabric/1.20.1/pack.toml
+++ b/versions/fabric/1.20.1/pack.toml
@@ -1,12 +1,12 @@
 name = "Adrenaline"
 author = "SkywardMC"
-version = "26.1.4+mc1.20.1.fabric"
+version = "26.1.5+mc1.20.1.fabric"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "12c65c6e702eb15e69f0f8e338676f564e7eb3d3b1ea2dc39ba6142862ea5f41"
+hash = "ec7f7112e31050899b7f84a590146068f72ac48214c2ae996787264f86ab1c90"
 
 [versions]
 fabric = "0.19.2"

--- a/versions/fabric/1.21.1/index.toml
+++ b/versions/fabric/1.21.1/index.toml
@@ -38,7 +38,7 @@ hash = "c402465b389607f17ecd45b44d5aef66a3750cef2d1c435189aaf81b667715b8"
 
 [[files]]
 file = "mods/c2me-fabric.pw.toml"
-hash = "7432b65e7551434c0ebff536e75f5dfb7e0cedb342ecf231523e4d6ca4e3e417"
+hash = "3fec3b665aa3c260075cabf00d04c75c6effd6b7b5f4e5e7a2c043b803d54ed8"
 metafile = true
 
 [[files]]
@@ -73,7 +73,7 @@ metafile = true
 
 [[files]]
 file = "mods/fabric-api.pw.toml"
-hash = "7494d3ab9667c29b19cc48b65e39b3623bd6c521e4357526176f71ace8ec17eb"
+hash = "8b055e1997973e615d20848f0c7d0712ebad4aa24ab8a3ee6d9682ea53642309"
 metafile = true
 
 [[files]]
@@ -98,7 +98,7 @@ metafile = true
 
 [[files]]
 file = "mods/ixeris.pw.toml"
-hash = "4a857daa8b136b3f5c9584dbb25509b7ebf11a034daed26c10d0a057526469d3"
+hash = "a7cfafa635b14ec5ad6f77cde164b56ad46f2f1a0590c862485870639ea0faa8"
 metafile = true
 
 [[files]]
@@ -138,7 +138,7 @@ metafile = true
 
 [[files]]
 file = "mods/servercore.pw.toml"
-hash = "487495097475b59d277ee8268149f0dca03b725479521c3dd830a37163598c2e"
+hash = "92f9b5aee5962bfe3dc2bd511ae680601d7fab55ab615fbebdaed8b7ccf66392"
 metafile = true
 
 [[files]]

--- a/versions/fabric/1.21.1/mods/c2me-fabric.pw.toml
+++ b/versions/fabric/1.21.1/mods/c2me-fabric.pw.toml
@@ -1,13 +1,13 @@
 name = "Concurrent Chunk Management Engine (Fabric)"
-filename = "c2me-fabric-mc1.21.1-0.3.0+alpha.0.363.jar"
+filename = "c2me-fabric-mc1.21.1-0.3.0+alpha.0.364.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/VSNURh3q/versions/mrXmbOac/c2me-fabric-mc1.21.1-0.3.0%2Balpha.0.363.jar"
+url = "https://cdn.modrinth.com/data/VSNURh3q/versions/1vHN61jT/c2me-fabric-mc1.21.1-0.3.0%2Balpha.0.364.jar"
 hash-format = "sha512"
-hash = "82ae4cdadc48ff3cec9aa02c197c6a108eceecbea40041ef3e146548c367548c2d596db5520a4384eceb7cc12e05ea172c29c51370d96fc558daf03c99117a63"
+hash = "4a3509986c1c5dc28be8b4137c463c6ff1d9fe2312052673a3a2d0c75c527d6dd40c3b2400af9fb7b416c5b430f3d1dc9f1db2b061dac8ae56ae4a5955edaa68"
 
 [update]
 [update.modrinth]
 mod-id = "VSNURh3q"
-version = "mrXmbOac"
+version = "1vHN61jT"

--- a/versions/fabric/1.21.1/mods/fabric-api.pw.toml
+++ b/versions/fabric/1.21.1/mods/fabric-api.pw.toml
@@ -1,13 +1,13 @@
 name = "Fabric API"
-filename = "fabric-api-0.116.11+1.21.1.jar"
+filename = "fabric-api-0.116.12+1.21.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/IpaMcBLh/fabric-api-0.116.11%2B1.21.1.jar"
+url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/Lwt6YYHL/fabric-api-0.116.12%2B1.21.1.jar"
 hash-format = "sha512"
-hash = "756b8c086f4c911d012f2eb70ca792aef0439503b31bc52026b82830870a94d472de30d61a6a0a9988c02b8462d9c47aa6baa6cd84da1eaf00edb77249b3c413"
+hash = "e2da98d9885b2d1c2d15b77bfdafa5df6c294cc96844ded739c8fd61a358fc69c4c391e3296534ea67806cb8ec8d250c0343c0b237c567d9740c586e6d67333a"
 
 [update]
 [update.modrinth]
 mod-id = "P7dR8mSH"
-version = "IpaMcBLh"
+version = "Lwt6YYHL"

--- a/versions/fabric/1.21.1/mods/ixeris.pw.toml
+++ b/versions/fabric/1.21.1/mods/ixeris.pw.toml
@@ -1,13 +1,13 @@
 name = "Ixeris"
-filename = "Ixeris-4.2.0+1.21.1-fabric.jar"
+filename = "Ixeris-4.3.0+1.21.1-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/p8RJPJIC/versions/AjFKcy3z/Ixeris-4.2.0%2B1.21.1-fabric.jar"
+url = "https://cdn.modrinth.com/data/p8RJPJIC/versions/BuuUeJU6/Ixeris-4.3.0%2B1.21.1-fabric.jar"
 hash-format = "sha512"
-hash = "d4fd98f358f51ec486e5cc426eef0bc7ea08307b58266a313f7753d83536ac3a3e75a0d66fafc2851853a615063b3e21105f00d9c8031cabff0c04cc727b9078"
+hash = "3fd1ff31fd533daeda475ce2ecf5c62663fa74d0983d684ac7dd4f43703f92f6f0912efa2d2ae63d73112f57cd8dd151f248de6529de0b874331df464ff1d61a"
 
 [update]
 [update.modrinth]
 mod-id = "p8RJPJIC"
-version = "AjFKcy3z"
+version = "BuuUeJU6"

--- a/versions/fabric/1.21.1/mods/scalablelux.pw.toml
+++ b/versions/fabric/1.21.1/mods/scalablelux.pw.toml
@@ -1,6 +1,6 @@
 name = "ScalableLux"
 filename = "ScalableLux-0.1.0.1+fabric.d0d58ab-all.jar"
-side = "server"
+side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/Ps1zyz6x/versions/Yx1tgJMI/ScalableLux-0.1.0.1%2Bfabric.d0d58ab-all.jar"

--- a/versions/fabric/1.21.1/mods/servercore.pw.toml
+++ b/versions/fabric/1.21.1/mods/servercore.pw.toml
@@ -1,13 +1,13 @@
 name = "ServerCore"
-filename = "servercore-fabric-1.5.10+1.21.1.jar"
+filename = "servercore-fabric-1.5.17+1.21.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/4WWQxlQP/versions/FDzBkBBD/servercore-fabric-1.5.10%2B1.21.1.jar"
+url = "https://cdn.modrinth.com/data/4WWQxlQP/versions/gooI6SAO/servercore-fabric-1.5.17%2B1.21.1.jar"
 hash-format = "sha512"
-hash = "dac68103d1ab69adeecdff220d391b4b5d9a826db1b94a8c5372fec8d5e6c41eb37ebc96b8361be84df5c3499a1b0e4d2a657d60df553b47dde133100666268d"
+hash = "c0b8655d41e66a8cdd1f83e3cd7a032f3d2e4dda1ce51e80a336a799a9fcfb695e3d526a0af360d779408b5b5173f2d2a5ffc1e6fbaf9dc03f48d0a8a65f40cf"
 
 [update]
 [update.modrinth]
 mod-id = "4WWQxlQP"
-version = "FDzBkBBD"
+version = "gooI6SAO"

--- a/versions/fabric/1.21.1/pack.toml
+++ b/versions/fabric/1.21.1/pack.toml
@@ -1,12 +1,12 @@
 name = "Adrenaline"
 author = "SkywardMC"
-version = "26.1.4+mc1.21.1.fabric"
+version = "26.1.5+mc1.21.1.fabric"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "dde809fab4a74e001d0968b9ecec986cba0c416ed543a0e88f8a9777722e9812"
+hash = "15b4f3ab22c32e2df4e51c51548317ae5f6912a4ff64898e601efb4b02c9b4d9"
 
 [versions]
 fabric = "0.19.2"

--- a/versions/fabric/1.21.10/index.toml
+++ b/versions/fabric/1.21.10/index.toml
@@ -35,7 +35,7 @@ metafile = true
 
 [[files]]
 file = "mods/c2me-fabric.pw.toml"
-hash = "4ee1808a7fb319d469dece5752cedb05dacb9afbe48021fa664f54b8c83fdc45"
+hash = "584dd7457a612ddbbeb429fc4dc2b153807f2538423fd16cae1b92b6274ad296"
 metafile = true
 
 [[files]]
@@ -90,7 +90,7 @@ metafile = true
 
 [[files]]
 file = "mods/ixeris.pw.toml"
-hash = "ae4df7339a87050b5dd04597cf5c83fd4ffe038a7817ccf9a0b22a2245b5cf94"
+hash = "25b319070234be85e1f79404b307941e7a79e469b92aed35449143f643721c62"
 metafile = true
 
 [[files]]
@@ -145,5 +145,5 @@ metafile = true
 
 [[files]]
 file = "mods/zfastnoise.pw.toml"
-hash = "474f043166ffde3f438f3305701c0e15d8640e90be68c90f7d38bad97fc02128"
+hash = "248b3f74f15b8502faa1a03cb4f655b2ad6e901a9b96a58eae222a381bc5673f"
 metafile = true

--- a/versions/fabric/1.21.10/mods/c2me-fabric.pw.toml
+++ b/versions/fabric/1.21.10/mods/c2me-fabric.pw.toml
@@ -1,13 +1,13 @@
 name = "Concurrent Chunk Management Engine (Fabric)"
-filename = "c2me-fabric-mc1.21.10-0.3.6+alpha.0.9.jar"
+filename = "c2me-fabric-mc1.21.10-0.3.6+alpha.0.11.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/VSNURh3q/versions/2EKX8Hiv/c2me-fabric-mc1.21.10-0.3.6%2Balpha.0.9.jar"
+url = "https://cdn.modrinth.com/data/VSNURh3q/versions/b2odfQPM/c2me-fabric-mc1.21.10-0.3.6%2Balpha.0.11.jar"
 hash-format = "sha512"
-hash = "71e193ecaa38e927a9f943eac6cac5b5dcb4ce6934aae994da9fe34cace5941fe25258056d8b9fdedbda87c5eb3787cad4c74e68ea39048cb6e86202a56dd7ec"
+hash = "aa94ef919927f0c78c22733eeb098f8cd3a32776869e5748082d9d7153dca9ad24335632d129a0016834dc6c99b162fe28492c3bdcac0cf22f0e92cef8226d02"
 
 [update]
 [update.modrinth]
 mod-id = "VSNURh3q"
-version = "2EKX8Hiv"
+version = "b2odfQPM"

--- a/versions/fabric/1.21.10/mods/ixeris.pw.toml
+++ b/versions/fabric/1.21.10/mods/ixeris.pw.toml
@@ -1,13 +1,13 @@
 name = "Ixeris"
-filename = "Ixeris-4.2.0+1.21.11-fabric.jar"
+filename = "Ixeris-4.3.0+1.21.11-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/p8RJPJIC/versions/WJiMd8Qu/Ixeris-4.2.0%2B1.21.11-fabric.jar"
+url = "https://cdn.modrinth.com/data/p8RJPJIC/versions/BefxE54b/Ixeris-4.3.0%2B1.21.11-fabric.jar"
 hash-format = "sha512"
-hash = "a7d47ad3cf6e139f774ac62b4e81e9e9754d5406f2f2c3abe1728d1486b04dbcbbc3301cdffc3a16823bdb72169fd2a6dd20fe3b3492a93571ef9e3f32ac7a4f"
+hash = "80c7f7236d01bca74ce93a38aade2ab05b45d6a96f84613530de8f2001db4b4bb5eeda43260d94f0beff533f9b41cd9c0cd19be69c64c0b15171d14509598d4b"
 
 [update]
 [update.modrinth]
 mod-id = "p8RJPJIC"
-version = "WJiMd8Qu"
+version = "BefxE54b"

--- a/versions/fabric/1.21.10/mods/scalablelux.pw.toml
+++ b/versions/fabric/1.21.10/mods/scalablelux.pw.toml
@@ -1,6 +1,6 @@
 name = "ScalableLux"
 filename = "ScalableLux-0.1.6+fabric.c25518a-all.jar"
-side = "server"
+side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/Ps1zyz6x/versions/PV9KcrYQ/ScalableLux-0.1.6%2Bfabric.c25518a-all.jar"

--- a/versions/fabric/1.21.10/mods/zfastnoise.pw.toml
+++ b/versions/fabric/1.21.10/mods/zfastnoise.pw.toml
@@ -1,13 +1,13 @@
 name = "Fast Noise"
-filename = "zfastnoise-1.0.29+1.21.9.jar"
+filename = "zfastnoise-1.0.32c+1.21.9.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/OnlVIpq5/versions/HIZTy9Pz/zfastnoise-1.0.29%2B1.21.9.jar"
+url = "https://cdn.modrinth.com/data/OnlVIpq5/versions/cPWrG8Qh/zfastnoise-1.0.32c%2B1.21.9.jar"
 hash-format = "sha512"
-hash = "209dcc8e3d6f5cd52402294035e662dd3d32106693e551fe37bd6eebaa45747c5e426c87e9ea7b6e18566a42117f3b108009882675f55079b45c66f030720d7f"
+hash = "d0959c52c93dfbb40110fd67a999163db903e6ac89b4c49da1bfe23fff1d803b4a8fab7a62023f1e49c1fc354224fa44e90d93f12189adee1326001937adfcef"
 
 [update]
 [update.modrinth]
 mod-id = "OnlVIpq5"
-version = "HIZTy9Pz"
+version = "cPWrG8Qh"

--- a/versions/fabric/1.21.10/pack.toml
+++ b/versions/fabric/1.21.10/pack.toml
@@ -1,12 +1,12 @@
 name = "Adrenaline"
 author = "SkywardMC"
-version = "26.1.4+mc1.21.10.fabric"
+version = "26.1.5+mc1.21.10.fabric"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "1a55e4aa99dbe73a4c6d487c3454d0981ad5c263e2ef1a76bbdf11fdd78509cb"
+hash = "560dfbc2d7415901233703bcd3828b3ae8c718099009cf9a6e53ddde9b3eb458"
 
 [versions]
 fabric = "0.19.2"

--- a/versions/fabric/1.21.11/index.toml
+++ b/versions/fabric/1.21.11/index.toml
@@ -30,12 +30,12 @@ hash = "c402465b389607f17ecd45b44d5aef66a3750cef2d1c435189aaf81b667715b8"
 
 [[files]]
 file = "mods/better-block-entities.pw.toml"
-hash = "1a94f1c48e896504687dbefb5969ad4749c9e406a7ce19eba8f58f41b458d145"
+hash = "b4cd1e372388fadea8346cb3e83ba043bbbb722d139d3ac4e56849c0bb46aade"
 metafile = true
 
 [[files]]
 file = "mods/c2me-fabric.pw.toml"
-hash = "037350c2aa47c78e4223154291da5d6dd51e515015d78741f64d3d7b71e25111"
+hash = "8049628241220dc47909f5d823511b6bf6c8a4cfd7bb212e031ee2acbbd9d7d3"
 metafile = true
 
 [[files]]
@@ -70,7 +70,7 @@ metafile = true
 
 [[files]]
 file = "mods/fabric-api.pw.toml"
-hash = "45abf05e1cc90006aeb65e4e1bbe97da5a1984f547ea8028a077dae68af0ac11"
+hash = "2ccce9c28059ea90a5457771de06a69b0a2d1f06d48f8add48a38f1a2307da3c"
 metafile = true
 
 [[files]]
@@ -95,7 +95,7 @@ metafile = true
 
 [[files]]
 file = "mods/ixeris.pw.toml"
-hash = "ae4df7339a87050b5dd04597cf5c83fd4ffe038a7817ccf9a0b22a2245b5cf94"
+hash = "25b319070234be85e1f79404b307941e7a79e469b92aed35449143f643721c62"
 metafile = true
 
 [[files]]
@@ -140,7 +140,7 @@ metafile = true
 
 [[files]]
 file = "mods/sodium.pw.toml"
-hash = "69bfe15c54b432a2ac2c791a71842d0fe0ea2dd7f84e59324cc4c76168b85a06"
+hash = "6747f2e71e6d9ae5b6c4aea899f6af5fbbb612aac8c9bbb45990463826af3398"
 metafile = true
 
 [[files]]
@@ -150,5 +150,5 @@ metafile = true
 
 [[files]]
 file = "mods/zfastnoise.pw.toml"
-hash = "fde6420147683142f25f0458a7d0027f0ee88c679f8bece191c7b9fe891bdeb7"
+hash = "5e3b150903977afa3e149d827cf0c8d6453626df3aff2117403ed93ad1dccdc7"
 metafile = true

--- a/versions/fabric/1.21.11/mods/better-block-entities.pw.toml
+++ b/versions/fabric/1.21.11/mods/better-block-entities.pw.toml
@@ -1,13 +1,13 @@
 name = "Better Block Entities"
-filename = "bbe-fabric-1.3.3+mc1.21.11.jar"
+filename = "bbe-fabric-1.3.4+mc1.21.11.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ONZm0H7Y/versions/b9BHiHB0/bbe-fabric-1.3.3%2Bmc1.21.11.jar"
+url = "https://cdn.modrinth.com/data/ONZm0H7Y/versions/VTUyYQyY/bbe-fabric-1.3.4%2Bmc1.21.11.jar"
 hash-format = "sha512"
-hash = "d9ff21d40478e04c28b296230a8c690b13155f60b5f66f158aa08fe3505891da5c82aae7449132171cc78a5b2ce9a9de382c77f129b3ecf101a96bd1d3f36951"
+hash = "1c8a513af8d9694cf9c41765cb8359aa3680ba9a1b8806d99c472ae325597db2c493a0389e602e3cf07b33c938b35012192504d5775c9cd3f308ab8c16376280"
 
 [update]
 [update.modrinth]
 mod-id = "ONZm0H7Y"
-version = "b9BHiHB0"
+version = "VTUyYQyY"

--- a/versions/fabric/1.21.11/mods/c2me-fabric.pw.toml
+++ b/versions/fabric/1.21.11/mods/c2me-fabric.pw.toml
@@ -1,13 +1,13 @@
 name = "Concurrent Chunk Management Engine (Fabric)"
-filename = "c2me-fabric-mc1.21.11-0.3.7+alpha.0.9.jar"
+filename = "c2me-fabric-mc1.21.11-0.3.7+alpha.0.10.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/VSNURh3q/versions/vsiqVtu6/c2me-fabric-mc1.21.11-0.3.7%2Balpha.0.9.jar"
+url = "https://cdn.modrinth.com/data/VSNURh3q/versions/UeCYljaE/c2me-fabric-mc1.21.11-0.3.7%2Balpha.0.10.jar"
 hash-format = "sha512"
-hash = "b2f92ef8a6dc7473305211c43dd54d509cb8a0dc2bbbd89e9267efb35b0a9871d0bb1a9b3c3e5c349bafa1a60567915e19f50d2b58bb90608556f93b290d72f6"
+hash = "2bec8077fc0209082776730b183633f08e328e570ecea9b3095bded6b09526cb694d0165046538c13f456e67c66895cd4dc2cebf91e2588f1cca76dc522b9962"
 
 [update]
 [update.modrinth]
 mod-id = "VSNURh3q"
-version = "vsiqVtu6"
+version = "UeCYljaE"

--- a/versions/fabric/1.21.11/mods/fabric-api.pw.toml
+++ b/versions/fabric/1.21.11/mods/fabric-api.pw.toml
@@ -1,13 +1,13 @@
 name = "Fabric API"
-filename = "fabric-api-0.141.3+1.21.11.jar"
+filename = "fabric-api-0.141.4+1.21.11.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/i5tSkVBH/fabric-api-0.141.3%2B1.21.11.jar"
+url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/5zJNhXV2/fabric-api-0.141.4%2B1.21.11.jar"
 hash-format = "sha512"
-hash = "c20c017e23d6d2774690d0dd774cec84c16bfac5461da2d9345a1cd95eee495b1954333c421e3d1c66186284d24a433f6b0cced8021f62e0bfa617d2384d0471"
+hash = "c092d48c6453bec3264f80f6a35bb334aba3112b5cd6c0e0b2676ce4d81e702cb1e522337f3a732348e757cc2226da3c601a314ae8766334f16af71a13bcc98d"
 
 [update]
 [update.modrinth]
 mod-id = "P7dR8mSH"
-version = "i5tSkVBH"
+version = "5zJNhXV2"

--- a/versions/fabric/1.21.11/mods/ixeris.pw.toml
+++ b/versions/fabric/1.21.11/mods/ixeris.pw.toml
@@ -1,13 +1,13 @@
 name = "Ixeris"
-filename = "Ixeris-4.2.0+1.21.11-fabric.jar"
+filename = "Ixeris-4.3.0+1.21.11-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/p8RJPJIC/versions/WJiMd8Qu/Ixeris-4.2.0%2B1.21.11-fabric.jar"
+url = "https://cdn.modrinth.com/data/p8RJPJIC/versions/BefxE54b/Ixeris-4.3.0%2B1.21.11-fabric.jar"
 hash-format = "sha512"
-hash = "a7d47ad3cf6e139f774ac62b4e81e9e9754d5406f2f2c3abe1728d1486b04dbcbbc3301cdffc3a16823bdb72169fd2a6dd20fe3b3492a93571ef9e3f32ac7a4f"
+hash = "80c7f7236d01bca74ce93a38aade2ab05b45d6a96f84613530de8f2001db4b4bb5eeda43260d94f0beff533f9b41cd9c0cd19be69c64c0b15171d14509598d4b"
 
 [update]
 [update.modrinth]
 mod-id = "p8RJPJIC"
-version = "WJiMd8Qu"
+version = "BefxE54b"

--- a/versions/fabric/1.21.11/mods/scalablelux.pw.toml
+++ b/versions/fabric/1.21.11/mods/scalablelux.pw.toml
@@ -1,6 +1,6 @@
 name = "ScalableLux"
 filename = "ScalableLux-0.1.6+fabric.c25518a-all.jar"
-side = "server"
+side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/Ps1zyz6x/versions/PV9KcrYQ/ScalableLux-0.1.6%2Bfabric.c25518a-all.jar"

--- a/versions/fabric/1.21.11/mods/sodium.pw.toml
+++ b/versions/fabric/1.21.11/mods/sodium.pw.toml
@@ -1,13 +1,13 @@
 name = "Sodium"
-filename = "sodium-fabric-0.8.11+mc1.21.11.jar"
+filename = "sodium-fabric-0.8.12+mc1.21.11.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/AANobbMI/versions/CL53p97Z/sodium-fabric-0.8.11%2Bmc1.21.11.jar"
+url = "https://cdn.modrinth.com/data/AANobbMI/versions/NFkjnzWE/sodium-fabric-0.8.12%2Bmc1.21.11.jar"
 hash-format = "sha512"
-hash = "a4f5535c3f6762c5f545b5d97069d8a07a1f7479d6e3cffe0eb65922878bf4a579c7e081e2536c6009a80fca8717f46451893f253045e4c247cf14de9dda6644"
+hash = "17fdb8240670d069e9bb4d00cd3d17afe28ea3f7ea7daf27fd32844f302516e7a889686429db81f2c7b73ad4afce703cac8963a8c3943cfebf45d2c570bd8256"
 
 [update]
 [update.modrinth]
 mod-id = "AANobbMI"
-version = "CL53p97Z"
+version = "NFkjnzWE"

--- a/versions/fabric/1.21.11/mods/zfastnoise.pw.toml
+++ b/versions/fabric/1.21.11/mods/zfastnoise.pw.toml
@@ -1,13 +1,13 @@
 name = "Fast Noise"
-filename = "zfastnoise-1.0.29+1.21.11.jar"
+filename = "zfastnoise-1.0.32c+1.21.11.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/OnlVIpq5/versions/iokxBbTT/zfastnoise-1.0.29%2B1.21.11.jar"
+url = "https://cdn.modrinth.com/data/OnlVIpq5/versions/1fs85W06/zfastnoise-1.0.32c%2B1.21.11.jar"
 hash-format = "sha512"
-hash = "18151ac6e803f7ff0ddcfc8680238ee052b0ae3fddafa8d2773a37de9965a41b8a0264591523f76361290ed40a44be6a448fb4d84e8e8a386a52f3292b9bc013"
+hash = "ca0726e37e270d97021f25db8cba309fbd68f844b7c2b292344b8c35aee78ca9aa0a824e44213590bd0861618a88027f16016092ed7ed8102417a52a58cd8635"
 
 [update]
 [update.modrinth]
 mod-id = "OnlVIpq5"
-version = "iokxBbTT"
+version = "1fs85W06"

--- a/versions/fabric/1.21.11/pack.toml
+++ b/versions/fabric/1.21.11/pack.toml
@@ -1,12 +1,12 @@
 name = "Adrenaline"
 author = "SkywardMC"
-version = "26.1.4+mc1.21.11.fabric"
+version = "26.1.5+mc1.21.11.fabric"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "3353e3a2d6b687a06eb4c5f73a67a883be415bea3c1ea3acfc593e59742aaf0b"
+hash = "db69a618bb22eceaf65ec0b3aae9acc96227ad6bcea730cdf6c9f54ee10183f3"
 
 [versions]
 fabric = "0.19.2"

--- a/versions/fabric/26.1.2/index.toml
+++ b/versions/fabric/26.1.2/index.toml
@@ -30,12 +30,12 @@ hash = "c402465b389607f17ecd45b44d5aef66a3750cef2d1c435189aaf81b667715b8"
 
 [[files]]
 file = "mods/better-block-entities.pw.toml"
-hash = "70840a6fafda10a17218ed11bfb2574af2d7ac06c3ce8f611e7d41517783be26"
+hash = "3a7f685358fe4eda8dc265f2d350c05e2cbc8c7a661e1d9676e72a02bc044a2b"
 metafile = true
 
 [[files]]
 file = "mods/c2me-fabric.pw.toml"
-hash = "05608f9174ebde171474deee51bc28ccf0a29d7594a6c0bdc40f06d2c7e32b50"
+hash = "82f8e930d470d72330d18b6609e233f5c61a37866cec7c93f17d9bc6006e7565"
 metafile = true
 
 [[files]]
@@ -70,7 +70,7 @@ metafile = true
 
 [[files]]
 file = "mods/fabric-api.pw.toml"
-hash = "5adf60faf11b97a7979f398fd6c494f55603a384880db1bf9755f2495d0dc5a2"
+hash = "2a77dc7aade5de6d21315582c4b70db40ff2bdf746b61c10d7ad3c5be8422f75"
 metafile = true
 
 [[files]]
@@ -95,7 +95,7 @@ metafile = true
 
 [[files]]
 file = "mods/ixeris.pw.toml"
-hash = "45db1736aeee554d2db425ad7da44c2d19ab30920d406816b93c34ab7dfe568a"
+hash = "fcb71635139025f0fec6588be1ee0270be391a145edecdcbc2eb199aca076bb8"
 metafile = true
 
 [[files]]
@@ -110,12 +110,17 @@ metafile = true
 
 [[files]]
 file = "mods/modernfix-mvus.pw.toml"
-hash = "dc12b3aba319df85cefde7e6fb0e89e59399fa304a2bbfacf812fb240c06380b"
+hash = "40ea7513ea7b648ad4fc392d549d52d3764ec87ee0b864c42f87e3a67a6356eb"
 metafile = true
 
 [[files]]
 file = "mods/modmenu.pw.toml"
-hash = "a3b2043845ab8f258b02e6cefe35e20f836ccc1e30acd6758fc98a772be87828"
+hash = "42583eed7ccb599f10285e721c25bf3c8858ef7e0eb8e22aa8bf64a08d98a280"
+metafile = true
+
+[[files]]
+file = "mods/particle-core.pw.toml"
+hash = "5f482c62b32f8f639a19640518cd77bc60d73bb422bcf7378eb1ced0680a2573"
 metafile = true
 
 [[files]]
@@ -130,12 +135,12 @@ metafile = true
 
 [[files]]
 file = "mods/servercore.pw.toml"
-hash = "207595c62114a11bc98dcb67c9b029fe3053a8e367cee9aadde8ed4d01a9c830"
+hash = "74b9be2bf4e2ba3b1c621cea436e14a0cd1a35423e8e02ea9eac51b340f8f299"
 metafile = true
 
 [[files]]
 file = "mods/sodium.pw.toml"
-hash = "b3bf6eb1cf803d702af91d3ca5f39e7528e1d55afdae03833f6e31698803caa9"
+hash = "e5278cc1dcda4fe789eaf05318fa5885f9f3412685f8ac231fe9a395409089e0"
 metafile = true
 
 [[files]]
@@ -145,5 +150,5 @@ metafile = true
 
 [[files]]
 file = "mods/zfastnoise.pw.toml"
-hash = "6d06b6fd8b81a3996e012d95a59f5076eca0e9fbf59bbfe7914ba1860f951f57"
+hash = "dd275d2b9f7edd1046117a4d03fb567f63b65218fc4b1abf2bcd3f0eb531f3ba"
 metafile = true

--- a/versions/fabric/26.1.2/mods/better-block-entities.pw.toml
+++ b/versions/fabric/26.1.2/mods/better-block-entities.pw.toml
@@ -1,13 +1,13 @@
 name = "Better Block Entities"
-filename = "bbe-fabric-1.3.3+mc26.1.2.jar"
+filename = "bbe-fabric-1.3.4+mc26.1.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ONZm0H7Y/versions/aTHgWr9a/bbe-fabric-1.3.3%2Bmc26.1.2.jar"
+url = "https://cdn.modrinth.com/data/ONZm0H7Y/versions/wdldM2VR/bbe-fabric-1.3.4%2Bmc26.1.2.jar"
 hash-format = "sha512"
-hash = "15c038a5b32c9d131d11dcb36eb61336749dfd2efbf206d1b399cae2f604d631af9b159f565a57738bb6ef1a1bdfccc445644f55c5044fff07700c527b22c6c8"
+hash = "ed6d77c6f93c131cb259c59c533b71c41581d424d14ca92764fe535bb784ff90c60c6d08072148f685606cf875733349ee381827b2d1a14623012e5761e465d6"
 
 [update]
 [update.modrinth]
 mod-id = "ONZm0H7Y"
-version = "aTHgWr9a"
+version = "wdldM2VR"

--- a/versions/fabric/26.1.2/mods/c2me-fabric.pw.toml
+++ b/versions/fabric/26.1.2/mods/c2me-fabric.pw.toml
@@ -1,13 +1,13 @@
 name = "Concurrent Chunk Management Engine (Fabric)"
-filename = "c2me-fabric-mc26.1.2-0.3.7+alpha.0.68.jar"
+filename = "c2me-fabric-mc26.1.2-0.3.7+alpha.0.69.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/VSNURh3q/versions/utLSz8Lf/c2me-fabric-mc26.1.2-0.3.7%2Balpha.0.68.jar"
+url = "https://cdn.modrinth.com/data/VSNURh3q/versions/iFyIEVsG/c2me-fabric-mc26.1.2-0.3.7%2Balpha.0.69.jar"
 hash-format = "sha512"
-hash = "34dd605aa81ff1270f9697cf0451ca9a6023e57f4873468ff01fc19e264d6434fbc0c108e194a6a675b0269dd16ed829f79a18ea06d32d89acda3fbf7675302f"
+hash = "32e5a21914ecd16b4560d2d59a4c1a96be92841d642cb278acd76461c0fe70e3875944917cb9e51dac719421d75abffd57bcbafe6e297e7477eaf34514857ced"
 
 [update]
 [update.modrinth]
 mod-id = "VSNURh3q"
-version = "utLSz8Lf"
+version = "iFyIEVsG"

--- a/versions/fabric/26.1.2/mods/fabric-api.pw.toml
+++ b/versions/fabric/26.1.2/mods/fabric-api.pw.toml
@@ -1,13 +1,13 @@
 name = "Fabric API"
-filename = "fabric-api-0.148.0+26.1.2.jar"
+filename = "fabric-api-0.149.1+26.1.2.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/KAvhN1it/fabric-api-0.148.0%2B26.1.2.jar"
+url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/BLz7ETCw/fabric-api-0.149.1%2B26.1.2.jar"
 hash-format = "sha512"
-hash = "4e9d39150af43869f68b03e91c51618a0d0c34ec7bfd57b515a9031364d35e391985ca1e2349daaa8d6f8fc88e4b96cfa5793bb0f98932ce0b3683fe4a238ce4"
+hash = "47ffa18369260c88ea847f6694ccb431a5aa9051c64e8d361186a767bb762dd9fcfbf4742ac65505eb60862900a1a3f1490994e7435376607de811eab8be4461"
 
 [update]
 [update.modrinth]
 mod-id = "P7dR8mSH"
-version = "KAvhN1it"
+version = "BLz7ETCw"

--- a/versions/fabric/26.1.2/mods/ixeris.pw.toml
+++ b/versions/fabric/26.1.2/mods/ixeris.pw.toml
@@ -1,13 +1,13 @@
 name = "Ixeris"
-filename = "Ixeris-4.2.0+26.1.2-fabric.jar"
+filename = "Ixeris-4.3.0+26.1.2-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/p8RJPJIC/versions/bcEeGj22/Ixeris-4.2.0%2B26.1.2-fabric.jar"
+url = "https://cdn.modrinth.com/data/p8RJPJIC/versions/Hv8IOiRR/Ixeris-4.3.0%2B26.1.2-fabric.jar"
 hash-format = "sha512"
-hash = "746ecd0e15f5ad6a608bba2f60d2072191f3dca3deaf910f713f795be3025bd90c2c7b2f2e2460f32f7e0609c74c966cf073931d8e8d58818bd5c93608087b93"
+hash = "6118c729f7469350c404a8e00a6c7efd40461acaf7967dce59afb46d8933c961350279dbee6264387628224186c2888b180212920b239d8e683ffd3defeec3bc"
 
 [update]
 [update.modrinth]
 mod-id = "p8RJPJIC"
-version = "bcEeGj22"
+version = "Hv8IOiRR"

--- a/versions/fabric/26.1.2/mods/modernfix-mvus.pw.toml
+++ b/versions/fabric/26.1.2/mods/modernfix-mvus.pw.toml
@@ -1,13 +1,13 @@
 name = "ModernFix-mVUS"
-filename = "modernfix-5.27.5-build.2.jar"
+filename = "modernfix-5.27.7-build.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/TjSm1wrD/versions/5REDoIHm/modernfix-5.27.5-build.2.jar"
+url = "https://cdn.modrinth.com/data/TjSm1wrD/versions/PDwZT2Ku/modernfix-5.27.7-build.1.jar"
 hash-format = "sha512"
-hash = "1ac2938e1cabe026ef667d6556874e1125ace2df1d0c0cd73fa6ee6224cd8850d00a2a92c90aa7ae9881c71a3dda628a18128fa7ce5fcd89247eadef6771c741"
+hash = "632f70ead073aff83df33854c0a3858807480b39b3542f15287b23bc6b2372417afda58872564aba21803bc3e6cb1bf92dca8d749d14b211696b20d6b221c36d"
 
 [update]
 [update.modrinth]
 mod-id = "TjSm1wrD"
-version = "5REDoIHm"
+version = "PDwZT2Ku"

--- a/versions/fabric/26.1.2/mods/modmenu.pw.toml
+++ b/versions/fabric/26.1.2/mods/modmenu.pw.toml
@@ -1,13 +1,13 @@
 name = "Mod Menu"
-filename = "modmenu-18.0.0-alpha.8.jar"
+filename = "modmenu-18.0.0-beta.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/mOgUt4GM/versions/jvjwXH6l/modmenu-18.0.0-alpha.8.jar"
+url = "https://cdn.modrinth.com/data/mOgUt4GM/versions/p7gjPPpV/modmenu-18.0.0-beta.1.jar"
 hash-format = "sha512"
-hash = "9a9e97047ac7b34ae34951d517bfc7c5fd48906beed61ee1e7c20b5ac2eac25348061b4227d9c98992a116ea98ff1d36fb745043b767c1e686ba279cda094930"
+hash = "b6a94b3f70fd4dd45f44a1edad6622a0de3ae57d9685bd0e97f1f928a8e07a62efd840174656f2cf189d7ca58a16760016d08bdf0a99286fe7df6289b10380dd"
 
 [update]
 [update.modrinth]
 mod-id = "mOgUt4GM"
-version = "jvjwXH6l"
+version = "p7gjPPpV"

--- a/versions/fabric/26.1.2/mods/particle-core.pw.toml
+++ b/versions/fabric/26.1.2/mods/particle-core.pw.toml
@@ -1,0 +1,13 @@
+name = "Particle Core"
+filename = "particle_core-0.3.2+26.1.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/RSeLon5O/versions/EkGqhJyz/particle_core-0.3.2%2B26.1.jar"
+hash-format = "sha512"
+hash = "871a6f289d3b599f973ba121306d51811dbeb1a42bb800d4cd3cb00c8d41bd7f47d0694eb5ea8f67b82e466d74dcb0901482b08cabafacdb814e97294c0e746c"
+
+[update]
+[update.modrinth]
+mod-id = "RSeLon5O"
+version = "EkGqhJyz"

--- a/versions/fabric/26.1.2/mods/scalablelux.pw.toml
+++ b/versions/fabric/26.1.2/mods/scalablelux.pw.toml
@@ -1,6 +1,6 @@
 name = "ScalableLux"
 filename = "ScalableLux-0.2.0+fabric.2b63825-all.jar"
-side = "server"
+side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/Ps1zyz6x/versions/gYbHVCz8/ScalableLux-0.2.0%2Bfabric.2b63825-all.jar"

--- a/versions/fabric/26.1.2/mods/servercore.pw.toml
+++ b/versions/fabric/26.1.2/mods/servercore.pw.toml
@@ -1,13 +1,13 @@
 name = "ServerCore"
-filename = "servercore-fabric-1.5.16+26.1.jar"
-side = "server"
+filename = "servercore-fabric-1.5.17+26.1.2.jar"
+side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/4WWQxlQP/versions/P8k080Af/servercore-fabric-1.5.16%2B26.1.jar"
+url = "https://cdn.modrinth.com/data/4WWQxlQP/versions/2siue87F/servercore-fabric-1.5.17%2B26.1.2.jar"
 hash-format = "sha512"
-hash = "ba8322c7569680f40f4162693623f488c17df0e8d394aaee20bbc8e1a3097aab3093896ea96e6839a36f817c1657bed89ba501316fa3980a15a5c0618e2d1a9e"
+hash = "b994f148565893024bd9e747d47396b30f2561d553cbae9849d2203066dbae5a45194b083955f6c98d217d0ad6b3b7027d1d9aedd823fb78a61768d3c228f525"
 
 [update]
 [update.modrinth]
 mod-id = "4WWQxlQP"
-version = "P8k080Af"
+version = "2siue87F"

--- a/versions/fabric/26.1.2/mods/sodium.pw.toml
+++ b/versions/fabric/26.1.2/mods/sodium.pw.toml
@@ -1,13 +1,13 @@
 name = "Sodium"
-filename = "sodium-fabric-0.8.11+mc26.1.2.jar"
+filename = "sodium-fabric-0.8.12+mc26.1.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/AANobbMI/versions/ff7xUQLH/sodium-fabric-0.8.11%2Bmc26.1.2.jar"
+url = "https://cdn.modrinth.com/data/AANobbMI/versions/eRJU33Hp/sodium-fabric-0.8.12%2Bmc26.1.2.jar"
 hash-format = "sha512"
-hash = "b60755799efb97f0d3d111c9d69887382da28aab3a7bf2fb4b7be7a9c6846f4f553421927c15a403c901c4b088773b82fdaa5af1a9414b19a627961e687ca66d"
+hash = "402bb945d1f893a72c152c137e08f8a0c045d725a4d6ca2af7bcfe929c4d80338da509094cfe3a8cd162346b78c5069dc3cf1d57bf94a1bce557f6425da7e76f"
 
 [update]
 [update.modrinth]
 mod-id = "AANobbMI"
-version = "ff7xUQLH"
+version = "eRJU33Hp"

--- a/versions/fabric/26.1.2/mods/zfastnoise.pw.toml
+++ b/versions/fabric/26.1.2/mods/zfastnoise.pw.toml
@@ -1,13 +1,13 @@
 name = "Fast Noise"
-filename = "zfastnoise-1.0.29-ocl+26.1.2.jar"
+filename = "zfastnoise-1.0.32c+26.1.2.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/OnlVIpq5/versions/sKqtVH3Z/zfastnoise-1.0.29-ocl%2B26.1.2.jar"
+url = "https://cdn.modrinth.com/data/OnlVIpq5/versions/Wo1nrWeb/zfastnoise-1.0.32c%2B26.1.2.jar"
 hash-format = "sha512"
-hash = "d5c7d38189fff63b71a48587694f09c4c5cc82ec3e80424cdce93ea2d99a783b447cfed5c640dba854a1417d6e2a576c7f403210b4c63a13e57495ff8f4ce11f"
+hash = "79f1025b52255e58a90be1293addd9e3d3fa254a122bb9501e1db80c74bc1a14a66914ae8311dd0cb31fe0a274e63ed99255bac5c0de9fc563a37d48deab5151"
 
 [update]
 [update.modrinth]
 mod-id = "OnlVIpq5"
-version = "sKqtVH3Z"
+version = "Wo1nrWeb"

--- a/versions/fabric/26.1.2/pack.toml
+++ b/versions/fabric/26.1.2/pack.toml
@@ -1,12 +1,12 @@
 name = "Adrenaline"
 author = "SkywardMC"
-version = "26.1.4+mc26.1.2.fabric"
+version = "26.1.5+mc26.1.2.fabric"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f9c1eb87c44d593d4f8f07fc593f246a35ad853e4c66a7a2b2362afe4dacf991"
+hash = "27bc772a3fe3703030fcce694a778602f94abe6c0fcba63f4f399344bbe74715"
 
 [versions]
 fabric = "0.19.2"


### PR DESCRIPTION
Closes #84 and #83.

- I didn't update sodium on 1.21.1 because there are some unsolved incompatibilities with some other mods, and because my game kept crashing. See [changelog on sodium](https://modrinth.com/mod/sodium/version/mc1.21.1-0.8.12-alpha.4-fabric).
- Updating to sodium in 26.1.2 apparently fixed a crash where constant redstone updates would trigger a crash.
- These changes were tested every 2 days for about a week.